### PR TITLE
corrected page title and layout

### DIFF
--- a/users/getting-started/system.md
+++ b/users/getting-started/system.md
@@ -1,14 +1,15 @@
-# Navigation
+# System menu and Getting Started Tour
 You can access the System menu by clicking on the left-most Kebab button (3 vertical dots) in the UI. 
 
-:::{figure} settings-menu.png
+:::{figure} settings-menu.png 
+System menu
+:::
 
 The System menu has the following items:
 
 - **About OpenSpace** - shows version information and a short description of the software
 - **Open Web Tutorials** - opens this documentation in your default web browser
 - **Open Getting Started Tour** - opens a wizard interface which gives a brief introduction to basic usage of OpenSpace, similar to this documentation on getting started![settings-menu](https://github.com/hn-88/OpenSpace-Docs/assets/6321069/28de5166-73bb-4f73-8270-cad53db2988a)
-
 - **Send Feedback** - opens a web form to send feedback.
 - **Show keybindings** - displays an onscreen keyboard with the currently configured keyboard short-cuts, the key bindings
 - **Toggle console** - shows or hides a one-line in-game [console](/users/console/index) at the top of the window, which allows precise control of the details in the scene


### PR DESCRIPTION
1. The top heading should have been System menu, I had inadvertently left it as Navigation.
2. The :::figure environment had not been closed, making the rest of the page center-aligned like a caption for the figure. Have now added a caption and closed the ::: figure environment.