### PR TITLE
Feature/0.20.0 propertyname changes

### DIFF
--- a/about/releases/changelogs/0.20.0/index.md
+++ b/about/releases/changelogs/0.20.0/index.md
@@ -16,13 +16,13 @@ Download version 0.20.0 for Windows and Mac on the OpenSpace website [installati
 Below is a list of breaking changes in this release.
 
 - A New Renderable for Point Clouds (`RenderableBillboardsCloud` -> `RenderablePointCloud`) [Details](./conversion.md#a-new-renderable-for-point-clouds)
-- `RenderableSphere` -> `RenderableSphereImageOnline` & `RenderableSphereImageLocal` (@TODO: Provide details)
+- `RenderableSphere` &rarr; `RenderableSphereImageOnline` & `RenderableSphereImageLocal` (@TODO: Provide details)
 - Property identifier changes
-  - RenderableAtmosphere: `EclipseHardShadowsInfo` -> `EclipseHardShadows`
-  - RenderableEclipseCone: `AmountOfPoints` -> `NumberOfPoints`
-  - RenderableShadowCylinder: `AmountOfPoints` -> `NumberOfPoints`
-  - RenderablePointCloud: `Coloring.OutlineWeight` -> `Coloring.OutlineWidth`
-  - RenderableOrbitalKepler: `Appearance.OutlineWeight` -> `Appearance.OutlineWidth`
+  - RenderableAtmosphere: `EclipseHardShadowsInfo` &rarr; `EclipseHardShadows`
+  - RenderableEclipseCone: `AmountOfPoints` &rarr; `NumberOfPoints`
+  - RenderableShadowCylinder: `AmountOfPoints` &rarr; `NumberOfPoints`
+  - RenderablePointCloud: `Coloring.OutlineWeight` &rarr; `Coloring.OutlineWidth`
+  - RenderableOrbitalKepler: `Appearance.OutlineWeight` &rarr; `Appearance.OutlineWidth`
   - All ScreenSpaceRenderables: `Gamma` -> `GammaOffset`
 
 :::{toctree}

--- a/about/releases/changelogs/0.20.0/index.md
+++ b/about/releases/changelogs/0.20.0/index.md
@@ -17,6 +17,12 @@ Below is a list of breaking changes in this release.
 
 - A New Renderable for Point Clouds (`RenderableBillboardsCloud` -> `RenderablePointCloud`) [Details](./conversion.md#a-new-renderable-for-point-clouds)
 - `RenderableSphere` -> `RenderableSphereImageLocal`/`RenderableSphereImageLocal` (@TODO: Provide details)
+- Property identifier changes
+  - RenderableAtmosphere: `EclipseHardShadowsInfo` -> `EclipseHardShadows`
+  - RenderableEclipseCone: `AmountOfPoints` -> `NumberOfPoints`
+  - RenderableShadowCylinder: `AmountOfPoints` -> `NumberOfPoints`
+  - RenderablePointCloud: `Coloring.OutlineWeight` -> `Coloring.OutlineWidth`
+  - RenderableOrbitalKepler: `Appearance.OutlineWeight` -> `Appearance.OutlineWidth`
 
 :::{toctree}
 :maxdepth: 1

--- a/about/releases/changelogs/0.20.0/index.md
+++ b/about/releases/changelogs/0.20.0/index.md
@@ -21,9 +21,8 @@ Below is a list of breaking changes in this release.
   - RenderableAtmosphere: `EclipseHardShadowsInfo` &rarr; `EclipseHardShadows`
   - RenderableEclipseCone: `AmountOfPoints` &rarr; `NumberOfPoints`
   - RenderableShadowCylinder: `AmountOfPoints` &rarr; `NumberOfPoints`
-  - RenderablePointCloud: `Coloring.OutlineWeight` &rarr; `Coloring.OutlineWidth`
   - RenderableOrbitalKepler: `Appearance.OutlineWeight` &rarr; `Appearance.OutlineWidth`
-  - All ScreenSpaceRenderables: `Gamma` -> `GammaOffset`
+  - All ScreenSpaceRenderables: `Gamma` &rarr; `GammaOffset`
 
 :::{toctree}
 :maxdepth: 1

--- a/about/releases/changelogs/0.20.0/index.md
+++ b/about/releases/changelogs/0.20.0/index.md
@@ -15,7 +15,7 @@ Download version 0.20.0 for Windows and Mac on the OpenSpace website [installati
 ## Breaking Changes
 Below is a list of breaking changes in this release.
 
-- A New Renderable for Point Clouds (`RenderableBillboardsCloud` -> `RenderablePointCloud`) [Details](./conversion.md#a-new-renderable-for-point-clouds)
+- A New Renderable for Point Clouds (`RenderableBillboardsCloud` &rarr; `RenderablePointCloud`) [Details](./conversion.md#a-new-renderable-for-point-clouds)
 - `RenderableSphere` &rarr; `RenderableSphereImageOnline` & `RenderableSphereImageLocal` (@TODO: Provide details)
 - Property identifier changes
   - RenderableAtmosphere: `EclipseHardShadowsInfo` &rarr; `EclipseHardShadows`

--- a/about/releases/changelogs/0.20.0/index.md
+++ b/about/releases/changelogs/0.20.0/index.md
@@ -16,7 +16,7 @@ Download version 0.20.0 for Windows and Mac on the OpenSpace website [installati
 Below is a list of breaking changes in this release.
 
 - A New Renderable for Point Clouds (`RenderableBillboardsCloud` -> `RenderablePointCloud`) [Details](./conversion.md#a-new-renderable-for-point-clouds)
-- `RenderableSphere` -> `RenderableSphereImageLocal`/`RenderableSphereImageLocal` (@TODO: Provide details)
+- `RenderableSphere` -> `RenderableSphereImageOnline` & `RenderableSphereImageLocal` (@TODO: Provide details)
 - Property identifier changes
   - RenderableAtmosphere: `EclipseHardShadowsInfo` -> `EclipseHardShadows`
   - RenderableEclipseCone: `AmountOfPoints` -> `NumberOfPoints`

--- a/about/releases/changelogs/0.20.0/index.md
+++ b/about/releases/changelogs/0.20.0/index.md
@@ -23,6 +23,7 @@ Below is a list of breaking changes in this release.
   - RenderableShadowCylinder: `AmountOfPoints` -> `NumberOfPoints`
   - RenderablePointCloud: `Coloring.OutlineWeight` -> `Coloring.OutlineWidth`
   - RenderableOrbitalKepler: `Appearance.OutlineWeight` -> `Appearance.OutlineWidth`
+  - All ScreenSpaceRenderables: `Gamma` -> `GammaOffset`
 
 :::{toctree}
 :maxdepth: 1


### PR DESCRIPTION
Add breaking property identifier changes from OpenSpace/OpenSpace#3226 to breaking changes for v0.20.0

Let me know what you think about this formatting. My idea is that we could add all breaking property changes in the same list. However, maybe we should sort them somehow?