### PR TITLE
Handle literal includes by creating pseudo-absolute paths. Make it possible to check out different branches. Make it possible to use local OpenSpace folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-﻿build
+﻿__pycache__
 .venv
+build
 generated

--- a/conf.py
+++ b/conf.py
@@ -3,7 +3,7 @@ import sys
 
 # The way Sphinx handles the path during the evaluation of the conf.py is a bit strange
 # so we have to add the current folder or else the `import` statement will fail
-sys.path.append(os.path.abspath('.'))
+sys.path.append(os.path.abspath("."))
 from generatedocs import generate_docs
 
 

--- a/conf.py
+++ b/conf.py
@@ -1,11 +1,16 @@
 import os
+import sys
+
+# The way Sphinx handles the path during the evaluation of the conf.py is a bit strange
+# so we have to add the current folder or else the `import` statement will fail
+sys.path.append(os.path.abspath('.'))
+from generatedocs import generate_docs
+
+
 
 # Generate the files that dynamically depend on asset files in the main OpenSpace repo
-with open("generatedocs.py", encoding="utf8") as file:
-  try:
-    exec(file.read())
-  except Exception as e:
-    print(e)
+generate_docs()
+
 
 ###
 # Global Settings

--- a/conf.py
+++ b/conf.py
@@ -84,7 +84,7 @@ html_context = {
 # This enables different logos in dark and light mode
 html_logo = "_static/transparent.png"
 
-html_title = f'OpenSpace documentation ({version})'
+html_title = f"OpenSpace documentation ({version})"
 html_short_title = "OpenSpace"
 
 html_favicon = "_static/icon.png"

--- a/conf.py
+++ b/conf.py
@@ -6,10 +6,25 @@ import sys
 sys.path.append(os.path.abspath("."))
 from generatedocs import generate_docs
 
+##########################################################################################
+#                                     CUSTOMIZATION                                      #
+##########################################################################################
+# This is the branch on the OpenSpace repository from which the documentation will be
+# built. Change this to a different branch to try a local branch before committing.
+# OBS: No other value than `master` should ever be committed to the master branch of the
+#      docs repository
+OPENSPACE_BRANCH = "master"
+
+# If this value is specified, instead of cloning OpenSpace from the main repository using
+# the branch provided above, instead use a local copy of the repository.
+# OBS: No other value than the empty string should ever be committed to the master branch
+#      of the docs repository
+LOCAL_OPENSPACE_FOLDER = ""
+
 
 
 # Generate the files that dynamically depend on asset files in the main OpenSpace repo
-generate_docs()
+generate_docs(OPENSPACE_BRANCH, LOCAL_OPENSPACE_FOLDER)
 
 
 ###

--- a/generatedocs.py
+++ b/generatedocs.py
@@ -3,7 +3,24 @@ from jinja2 import Environment, FileSystemLoader # template magic
 import json # reading the input file
 import os # file paths
 import re # regex for searching for assets files
+import shutil # copytree, rmtree
 from tqdm import tqdm # progress bar
+
+##########################################################################################
+#                                     CUSTOMIZATION                                      #
+##########################################################################################
+# This is the branch on the OpenSpace repository from which the documentation will be
+# built. Change this to a different branch to try a local branch before committing.
+# OBS: No other value than `master` should ever be committed to the master branch of the
+#      docs repository
+OPENSPACE_BRANCH = "master"
+
+# If this value is specified, instead of cloning OpenSpace from the main repository using
+# the branch provided above, instead use a local copy of the repository.
+# OBS: No other value than the empty string should ever be committed to the master branch
+#      of the docs repository
+LOCAL_OPENSPACE_FOLDER = ""
+
 
 ##########################################################################################
 #                           ASSET COMPONENTS HELPER FUNCTIONS                            #
@@ -15,6 +32,23 @@ def clone_assets_folder(folder_name):
   Uses the latest master
   Returns absolute path to the asset folder
   """
+  data_assets_path = "data/assets"
+
+  if LOCAL_OPENSPACE_FOLDER != "":
+    print(f"Using local OpenSpace folder {LOCAL_OPENSPACE_FOLDER}")
+    # If a local folders was provided, we don't have to do any of the cloning work, but we
+    # must copy the files for any potential `literalinclude` directive to work
+    os.makedirs(os.path.join(folder_name, "data"), exist_ok=True)
+    source_path = os.path.join(LOCAL_OPENSPACE_FOLDER, data_assets_path)
+    destination_path = os.path.join(folder_name, data_assets_path)
+    if os.path.exists(destination_path):
+      shutil.rmtree(destination_path)
+    shutil.copytree(source_path, destination_path)
+
+    return os.path.abspath(destination_path)
+
+  # Otherwise (the default path), we need to clone the OpenSpace repository and checkout
+  # the requested branch
   def print_progress(op_code, cur_count, max_count=None, message=""):
     print(message)
 
@@ -30,9 +64,8 @@ def clone_assets_folder(folder_name):
   print(f"Fetching OpenSpace... this might take a while")
   origin.fetch(progress=print_progress, depth=1)
 
-  data_assets_path = "data/assets"
   git = repo.git()
-  git.checkout("origin/master", "--", data_assets_path)
+  git.checkout(f"origin/{OPENSPACE_BRANCH}", "--", data_assets_path)
   print("Done cloning assets folder from OpenSpace repository")
   assets_folder_path = os.path.abspath(os.path.join(folder_name, data_assets_path))
   return assets_folder_path
@@ -68,11 +101,13 @@ def get_lines_and_content_from_file(asset_file, regex, look_for_header = False):
   header = ""
   content = ""
   description = ""
-  LUA_COMMENT = "-- "
+  LUA_COMMENT = "--"
+  LITERAL_INCLUDE = "```{literalinclude} "
   header_finished = 0
   with open(asset_file, "r", encoding="utf8") as file:
     if not file.readable():
       return None
+
     # Read file line by line
     for l_no, line in enumerate(file, 1):
       # Check for header comment at top of file
@@ -81,10 +116,32 @@ def get_lines_and_content_from_file(asset_file, regex, look_for_header = False):
 
       # If we are in header comment, split into header and description
       if look_for_header and is_header_comment:
-        comment = line.split(LUA_COMMENT)[1]
+        # Remove the beginning of the line that marks it being a Lua comment
+        comment = line[len(LUA_COMMENT):]
+        if comment[0] == " ":
+          comment = comment[1:]
+
         if l_no == 1:
+          # The first line becomes the header
           header = comment
         else:
+          if comment.startswith(LITERAL_INCLUDE):
+            # Literal includes have to be handled a bit separately. While writing examples
+            # we want to pretend that the file we are including is relative to the Lua
+            # file, but for Sphinx, it is relative to the Markdown file. To solve this, we
+            # make use of the fact that Sphinx will treat any path to a literalinclude
+            # that starts with a / as a path relative to the _base folder_. So we can
+            # switch out the path at the last minute and make sure that it gets correctly
+            # included
+            print("Before", comment)
+            path = comment[len(LITERAL_INCLUDE):]
+
+            # We need to get the path to the asset file relative to the base folder
+            full_folder = os.path.dirname(asset_file)
+            rel_folder = os.path.relpath(full_folder)
+            comment = f"{LITERAL_INCLUDE} /{rel_folder}/{path}"
+            print("After", comment)
+
           description += comment
           header_finished = l_no + 1
       # Else, get the content of the example
@@ -97,7 +154,12 @@ def get_lines_and_content_from_file(asset_file, regex, look_for_header = False):
 
   # If there were any matches to regex, set the content as the example
   if len(lines) > 0:
-    return { "header": header, "description": description, "content": content, "lines": lines }
+    return {
+      "header": header,
+      "description": description,
+      "content": content,
+      "lines": lines
+    }
   else:
     return None
 
@@ -242,8 +304,7 @@ def generate_asset_components(environment, output_folder, folder_name_assets, js
 
   # Create target folder
   assets_output_path = os.path.join(output_folder, folder_name_assets)
-  if not os.path.exists(assets_output_path):
-    os.mkdir(assets_output_path)
+  os.makedirs(assets_output_path, exist_ok=True)
 
   f = open(os.path.join(json_location, "assetComponents.json"))
   asset_categories = json.load(f)
@@ -254,6 +315,7 @@ def generate_asset_components(environment, output_folder, folder_name_assets, js
   # Missing and found asset files
   components_missing_assets = []
   no_of_found_assets = 0
+  print("Handle individual components")
   for category in asset_categories:
     # Find base class to add its members to each derived class
     base_class_name = category["name"]
@@ -266,7 +328,7 @@ def generate_asset_components(environment, output_folder, folder_name_assets, js
         break
 
     # Go through all the components in that category and print out a md file
-    for asset_component in tqdm(category["classes"], desc="Generating asset components for " + category["name"]):
+    for asset_component in tqdm(category["classes"], desc=category["name"]):
       is_base_class = has_base_class and asset_component["name"] == base_class["name"]
       base_class_name = base_class["name"] if has_base_class and not is_base_class else ""
       base_class_identifier = base_class["identifier"] if has_base_class and not is_base_class else ""
@@ -339,8 +401,7 @@ def generate_scripting_api(environment, output_folder, folder_name_scripting, js
   """
   # Create target folder
   scripting_output_path = os.path.join(output_folder, folder_name_scripting)
-  if not os.path.exists(scripting_output_path):
-    os.mkdir(scripting_output_path)
+  os.makedirs(scripting_output_path, exist_ok=True)
 
   f = open(os.path.join(json_location, "scriptingApi.json"))
   scripting_api = json.load(f)
@@ -398,16 +459,19 @@ def generate_renderable_overview(environment, output_folder, json_location):
 #                                         MAIN                                           #
 ##########################################################################################
 
-json_location = "json"
-output_folder = "generated"
-folder_name_assets = "asset-components"
-folder_name_scripting = "scripting-api"
+def generate_docs():
+  print("Generating dynamic documentation")
 
-# Load jinja templates folder
-environment = Environment(loader=FileSystemLoader("templates"))
+  json_location = "json"
+  output_folder = "generated"
+  folder_name_assets = "asset-components"
+  folder_name_scripting = "scripting-api"
 
-# Generate documentation
-generate_asset_components(environment, output_folder, folder_name_assets, json_location)
-generate_scripting_api(environment, output_folder, folder_name_scripting, json_location)
-generate_renderable_overview(environment, output_folder, json_location)
+  # Load jinja templates folder
+  environment = Environment(loader=FileSystemLoader("templates"))
+
+  # Generate documentation
+  generate_asset_components(environment, output_folder, folder_name_assets, json_location)
+  generate_scripting_api(environment, output_folder, folder_name_scripting, json_location)
+  generate_renderable_overview(environment, output_folder, json_location)
 


### PR DESCRIPTION
1. For the literalinclude issue where the file could not be found, the script now changes the path while parsing the header comment. Instead of leaving the file as a relative file (which makes sense when writing the Lua script to assume it would be relative to this file), it is rewritten as a pseudo-relative file that Sphinx understands.  Any path to a literalinclude that stars with a `/` is assumed to be relative to the base folder of the Sphinx built.  So essentially a `/generated/asset_examples/data/.../` is added to every `literalinclude` directive, which makes the LuaTranslation, LuaRotation, and LuaScale PRs work
2. Changed the way the generatedocs.py is being called by using an `import` statement instead
3. To make it easier to test I first thought it would be nice to test against a different branch than `master` so I added that feature, but I didn't _really_ need it and did
4. The ability to specify a local OpenSpace instance that is used instead of cloning it from the repo

For both 3 and 4 the default behavior leaves the script unchanged and it will clone the `master` branch from the repository as normal