### PR TITLE
Implemented community page. Fixed typos

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -2,12 +2,12 @@
 
 Here is information about the various ways you can access the OpenSpace community:
 
-* [Slack Group](https://app.slack.com/client/T667GT03H/C055D75TJ9K) - Join our Slack channel to ask questions, share videos, and get help from other community members.
+- [Slack Group](https://app.slack.com/client/T667GT03H/C055D75TJ9K) - Join our Slack channel to ask questions, share videos, and get help from other community members.
 
-* [Email](mailto:support@openspaceproject.com) - Reach out to us via email for any inquiries or assistance.
+- [Email](mailto:support@openspaceproject.com) - Reach out to us via email for any inquiries or assistance.
 
-* [Reddit](https://www.reddit.com/r/OpenSpaceProject/) - Visit our reddit for discussions, updates, and community contributions.
+- [Reddit](https://www.reddit.com/r/OpenSpaceProject/) - Visit our reddit for discussions, updates, and community contributions.
 
-* [Instagram](https://www.instagram.com/openspaceproj/) - Follow us on Instagram for visual updates.
+- [Instagram](https://www.instagram.com/openspaceproj/) - Follow us on Instagram for visual updates.
 
-* [YouTube](https://www.youtube.com/c/openspacesoftware) - Explore our YouTube channel for tutorial videos, project showcases etc.
+- [YouTube](https://www.youtube.com/c/openspacesoftware) - Explore our YouTube channel for tutorial videos, project showcases etc.

--- a/community/index.md
+++ b/community/index.md
@@ -1,3 +1,13 @@
 # Community
 
-Here is information about the various ways you can access the OpenSpace community.
+Here is information about the various ways you can access the OpenSpace community:
+
+* [Slack Group](https://app.slack.com/client/T667GT03H/C055D75TJ9K) - Join our Slack channel to ask questions, share videos, and get help from other community members.
+
+* [Email](mailto:support@openspaceproject.com) - Reach out to us via email for any inquiries or assistance.
+
+* [Reddit](https://www.reddit.com/r/OpenSpaceProject/) - Visit our reddit for discussions, updates, and community contributions.
+
+* [Instagram](https://www.instagram.com/openspaceproj/) - Follow us on Instagram for visual updates.
+
+* [YouTube](https://www.youtube.com/c/openspacesoftware) - Explore our YouTube channel for tutorial videos, project showcases etc.

--- a/contribute/development/compiling/macos.md
+++ b/contribute/development/compiling/macos.md
@@ -11,7 +11,7 @@ Xcode includes git, but the Xcode IDE cannot deal with recursive submodules. Onc
 
 
 ## Dependencies
-Homebrew is billed as "the missing package manager" for macOS. Homewbrew installs the stuff you need that Apple didn't. It's easy to install and uninstall packages with Homebrew. See [http://brew.sh](http://brew.sh) for instructions and to download and install Homebrew.
+Homebrew is billed as "the missing package manager" for macOS. Homewbrew installs the stuff you need that Apple didn't provide. It's easy to install and uninstall packages with Homebrew. See [http://brew.sh](http://brew.sh) for instructions and to download and install Homebrew.
 
 Once you have installed homebrew you can use it to install other useful utilities and libraries. Specifically, to build OpenSpace you will need to do the following:
 ```bash
@@ -23,7 +23,7 @@ Similarly if you are using MacPorts, the corresponding command is:
 port install glew boost freeimage mpv vulkan-headers vulkan-loader brotli gdal +curl
 ```
 
-Please make use that the correct GDAL version is installed, as OpenSpace uses some recent features. We require a version that is newer than `2.4`.
+Please make sure that the correct GDAL version is installed, as OpenSpace uses some recent features. We require a version that is newer than `2.4`.
 
 ## Compiling
 In Xcode, you need to select the target/scheme `ALL_BUILD` (if it isn't already) and build it (pull down {menuselection}`Product --> Build`). Verify the build type (`Release` | `Debug`) by browsing to {menuselection}`Product --> Scheme --> Edit Scheme --> Info tab --> Build Configuration`.

--- a/contribute/development/compiling/ubuntu.md
+++ b/contribute/development/compiling/ubuntu.md
@@ -55,7 +55,7 @@ make -j
 ## Outdated Versions of Ubuntu
 Currently, pre-22.04 versions of Ubuntu use versions of `libmpv-dev` that are too old. An up-to-date debian package for mpv installation can be downloaded from [here](https://mpv.io/installation/), which would install an updated version of `libmpv-dev`.
 
-Similarly, `qt6-base-dev` is not available but can be installed through other means such as [aqtinstall](https://github.com/miurahr/aqtinstall)
+Similarly, `qt6-base-dev` is not available but can be installed through other means such as [aqtinstall](https://github.com/miurahr/aqtinstall).
 
 You can install gcc-13 using the following commands in case it is not supported:
 The final commands configure Ubuntu's "update-alternatives", which allows a user to select among multiple installations of gcc:

--- a/contribute/development/compiling/windows.md
+++ b/contribute/development/compiling/windows.md
@@ -2,7 +2,7 @@
 This page contains specific information necessary to compile OpenSpace on Windows. This page has the [general instructions](index) as a required reading.
 
 ## Development Tools
-[Visual Studio 2022](http://www.visualstudio.com) is the standard Interactive Development Environment (IDE)d for Windows. The "community" version is a free download for open-source projects. When you install it, be sure to select "Custom" configuration and select the C++ compiler -- it might not be included by default. You can also select a git client here ("Git GUI"). Installation could take a while (like an hour or so, depending on the machine). We are following the development of the C++ language quite closely, so there are more and more features that are no longer supported in Visual Studio 2019 or earlier versions.
+[Visual Studio 2022](http://www.visualstudio.com) is the standard Interactive Development Environment (IDE) for Windows. The "community" version is a free download for open-source projects. When you install it, be sure to select "Custom" configuration and select the C++ compiler -- it might not be included by default. You can also select a git client here ("Git GUI"). Installation could take a while (like an hour or so, depending on the machine). We are following the development of the C++ language quite closely, so there are more and more features that are no longer supported in Visual Studio 2019 or earlier versions.
 
 ## Dependencies
 ### Qt

--- a/contribute/development/tools/visual-studio.md
+++ b/contribute/development/tools/visual-studio.md
@@ -1,7 +1,7 @@
 # Visual Studio Tips and Tricks
 
 ## Detecting Exceptions
-A common problem is that an exception is thrown somewhere in the code and we can only put a breakpoint in the `catch` part at which point we have lost the stack information of where the exception orginated from and finding that out can be cumbersome.
+A common problem is that an exception is thrown somewhere in the code and we can only put a breakpoint in the `catch` part at which point we have lost the stack information of where the exception originated from and finding that out can be cumbersome.
 
 {menuselection}`Debug --> Exception Settings --> C++ Exceptions --> <All C++ Exceptions not in this list>` should be checked
 
@@ -9,7 +9,7 @@ If that checkbox is selected, Visual Studio will break every time a C++ exceptio
 
 
 ## Breaking on floating point exceptions
-Sometimes numbers break, for example `float x = std::sqrt(-1.0)` would store a a NaN, which would then propagate further into other calculations. Finding the source error of this can be very tedious and cumbersome as it involves a lot of (`assert(x == x)`).
+Sometimes numbers break, for example `float x = std::sqrt(-1.0)` would store as a NaN, which would then propagate further into other calculations. Finding the source error of this can be very tedious and cumbersome as it involves a lot of (`assert(x == x)`).
 
 Doing this somewhere early in the program:
 ```cpp


### PR DESCRIPTION
I'm new to Open Source and GitHub, and I love what you guys are doing with this software. So, I wanted to contribute something that I felt comfortable with for now. With that in mind, after reviewing the OpenSpace documentation, I noticed that the community page wasn't implemented. Therefore, I implemented it along with fixing some typos that I found while reading it. I would love to receive feedback about the implementation of the community page. I was thinking of adding the link to the discussion section on GitHub.

> Development / Compiling / Windows
Fixed typo: "IDE)d" changed to "IDE."

>  Development / Compiling / Ubuntu
Added period at the end of "aqtinstall."

> Development / Compiling / macOS
Updated note about GDAL version requirement.
Clarified sentence about Homebrew installation.

>  Development / Tools / Visual Studio Tips and Tricks
Fixed typos: "orginated" to "originated," "a a NaN" to "as a NaN," "particlar" to "particular."

> Community
Added links for community access:
Slack Group (Description...)
Email contact
Reddit
Instagram
YouTube

