### PR TITLE
Feature/local build instructions update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ﻿__pycache__
 .venv
 build
+reference/asset_examples
 reference/asset-components
 reference/scripting-api
 reference/renderable-overview.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OpenSpace Documentation
+
 This repository contains the source of the documentation for OpenSpace. The documentation is written in [MyST](https://myst-parser.readthedocs.io/en/latest/index.html), a Markdown syntax extension, converted into an HTML page using [Sphinx](https://www.sphinx-doc.org/en/master/), and then finally hosted by [Read the Docs](https://about.readthedocs.com/?ref=readthedocs.com) at https://docs.openspaceproject.com.
 
 As of now, the documentation relies heavily of the Godot documentation page for both styling and functionality.
@@ -8,36 +9,65 @@ Part of this documentation (the `Reference` section) is generated from `json` ob
 Every commit and pull request to this repository will trigger a new build of the documentation. The `master` will build into the "latest" version and each versioned tag is selectable in the flyout menu, with the last version being marked as "stable".
 
 ## Building the documentation locally
+
 During the development it is beneficial to build the documentation page locally to see the results before committing something into the repository that fails to build or that produces warnings.
 
-  1. In a shell, move to this directory.
-  2. Run `python -m venv .venv` to create a python virtual environment.
-  3. Run `.\.venv\Scripts\activate` to activate the python virtual environment.
-  4. `pip install -r requirements.txt` (this is technically only necessary for the first time or when the dependencies change, but it is a good habit to run this every time after a checkout).
-  5. Run `make html`.
+1. In a shell, move to this directory.
+2. Run `python -m venv .venv` to create a python virtual environment.
+3. Run `.\.venv\Scripts\activate` to activate the python virtual environment.
+4. `pip install -r requirements.txt` (this is technically only necessary for the first time or when the dependencies change, but it is a good habit to run this every time after a checkout).
+5. (optional) Generate the files for the OpenSpace reference, and alternatively also the asset examples if you want to use versions different than the ones on the origin/master branch. See section "Generate OpenSpace reference" below for details.
+6. Run `make html`/`.\make.bat html`.
 
 This will create a `build/html` folder structure that contains a `index.html` which you can open in a webbrowser to view the documentation.
 
 Before committing to the repository it can also be beneficial to run `./make.bat linkcheck` which checks whether all links referenced in the document are actually correct or if we have links that are now dead.
 
-## Make commands
+### Make commands
 
 - `make html` will build the documentation locally.
 - `make clean` will clean out the build folder and remove everything built previously.
 - `make linkcheck` will check so that all links are correct.
 
+### Generate OpenSpace reference (optional)
+
+If you have updated documentation for the Scripting API or the Asset Components (including example files) in the engine, you might want to view these changes in the documentation. The following steps describe how to do this.
+
+1. Set the `genereate_reference` variable in `conf.py` to `True`. This will result in the files being regenerated when you run `make html`. Otherwise, the generation is only done if the files do not already exist.
+
+2. (optional) If you are working on example assets, you may also want to change where the source files for those examples are acquired form. Per default, the generation script will download a partial clone of the OpenSpace repository (only the assets folder) from the _latest master_ and then generate the documentation. However, you can change this through the following setting in `conf.py`:
+
+   - `assets_examples_use_github`: Set to `True` to use an OpenSpace repository from Github. Set to `False` to use a local copy or repository.
+   - `assets_release`: If using Github, set this string to the branch name (e.g. `origin/feature/feature-branch`), or to a tag name for a specific OpenSpace release (e.g. `releases/0.20.0` for version 0.20.0). If empty, `origin/master` is used.
+   - `assets_local_openspace_folder`: If using a local OpenSpace repository, set this string to the path to the OpenSpace folder, e.g. `C:/dev/OpenSpace`.
+
+3. (optional) Generate new `.json` files needed for the documentation using Cmake and Visual Studio. This is only needed if you have made changes in the OpenSpace source code that you want to be reflected on the local build of the documentation page.
+
+   1. Open your OpenSpace project in CMake and enable the `OPENSPACE_APPLICATION_DOCSWRITER` checkbox in CMake. Re-generate the project.
+
+   2. Once we have a project where the DocsWriter is generated, make the DocsWriter your startup project in Visual Studio.
+
+   3. Build and run the DocsWriter project. This will generate two JSON files in the `documentation` folder: `assetComponents.json` and `scriptingApi.json`.
+
+   4. Move the two generated files `assetComponents.json` and `scriptingApi.json` to the `OpenSpace-Docs/json` folder. Replace any existing files.
+
+4. Run `make html`/`.\make.bat html` to build the documentation, as usual.
+
 ## File Structure
+
 Each major grouping in the documentation should have a separate folder in the repository that collects all of the files describing things belonging to that major category.
-  - `generated`: The directory where all generated markdown files will be placed. These will be shown in the `Reference` section of the documentation.
-  - `templates`: This is where the jinja templates are stored that are used to structure the markdown files. 
-  - `_static`: Files placed in this folder are automatically copied into the resulting documentation. In general, it is not necessary to manually place files in here as Sphinx is copying required files from other places automatically
-  - `.readthedocs.yml`: A configuration file that sets up the build environment to build the documentation. Documentation for this file can be found [here](https://docs.readthedocs.io/en/stable/config-file/v2.html).
-  - `conf.py`: A Python script that configures the actual Sphinx instance that builds the documentation page. Documentation for this file can be found [here](https://www.sphinx-doc.org/en/master/usage/configuration.html) and [here](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html).
-  - `requirements.txt`: A PIP requirements file that describes all of the Python package requirements that need to be installed.
-  - `make.bat` / `Makefile`: A batch script for Windows or bash script for Linux to build the documentation. The script needs a second parameter that describes the output type, by default we use `html` for our documentation or `linkcheck` to check whether links in the files are correct. `clean` can be used to remove existing files to build the documentation from scratch, for example via `make.bat clean && make.bat html`.
+
+- `generated`: The directory where all generated markdown files will be placed. These will be shown in the `Reference` section of the documentation.
+- `templates`: This is where the jinja templates are stored that are used to structure the markdown files.
+- `_static`: Files placed in this folder are automatically copied into the resulting documentation. In general, it is not necessary to manually place files in here as Sphinx is copying required files from other places automatically
+- `.readthedocs.yml`: A configuration file that sets up the build environment to build the documentation. Documentation for this file can be found [here](https://docs.readthedocs.io/en/stable/config-file/v2.html).
+- `conf.py`: A Python script that configures the actual Sphinx instance that builds the documentation page. Documentation for this file can be found [here](https://www.sphinx-doc.org/en/master/usage/configuration.html) and [here](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html).
+- `requirements.txt`: A PIP requirements file that describes all of the Python package requirements that need to be installed.
+- `make.bat` / `Makefile`: A batch script for Windows or bash script for Linux to build the documentation. The script needs a second parameter that describes the output type, by default we use `html` for our documentation or `linkcheck` to check whether links in the files are correct. `clean` can be used to remove existing files to build the documentation from scratch, for example via `make.bat clean && make.bat html`.
 
 When adding images that require different files for light-mode and dark-mode, the file should be named normally for the light version and have the suffix `_dark` for the dark-mode version of the images. Example:
-  - `scenemenu.png`: Light-mode version.
-  - `scenemenu_dark.png`: Dark-mode version.
+
+- `scenemenu.png`: Light-mode version.
+- `scenemenu_dark.png`: Dark-mode version.
 
 If the same image can be used for both light and dark mode, the normal name would be used: `scenemenu.png`

--- a/_ext/generate_docs.py
+++ b/_ext/generate_docs.py
@@ -458,24 +458,28 @@ def generate_renderable_overview(environment, output_folder, json_location):
 ##########################################################################################
 
 def generate_docs(app, config):
-  if not config.generate_assets_examples:
-    print("Skipping generating new assets examples...")
-    print("To generate set 'generate_assets_examples' to True in the conf.py file")
-    return
-
-  print("Generating dynamic documentation")
-
-  # Get config values
-  use_github = config.assets_examples_use_github
-  release_tag = config.assets_release
-  local_openspace_folder = config.assets_folder
-
   # Name variables
   json_location = "json"
   output_folder = "reference"
   folder_name_assets = "asset-components"
   folder_name_scripting = "scripting-api"
   assset_examples_output = os.path.join(output_folder, "asset_examples")
+
+  # Check if the reference has already been generated. Note that we assume that this is
+  # the case if the asset examples folder exists
+  reference_already_generated = os.path.exists(assset_examples_output)
+
+  if not config.generate_reference and reference_already_generated:
+    print("Skipping generating new assets examples...")
+    print("To generate set 'generate_reference' to True in the conf.py file")
+    return
+
+  print("Generating dynamic documentation (the reference)")
+
+  # Get config values
+  use_github = config.assets_examples_use_github
+  release_tag = config.assets_release
+  local_openspace_folder = config.assets_local_openspace_folder
 
   assets_folder = None
   if use_github:
@@ -507,10 +511,10 @@ def generate_docs(app, config):
 #                                         Sphinx setup                                   #
 ##########################################################################################
 def setup(app: Sphinx) -> ExtensionMetadata:
-    app.add_config_value('generate_assets_examples', True, 'bool')
+    app.add_config_value('generate_reference', True, 'bool')
     app.add_config_value('assets_examples_use_github', True, "bool")
     app.add_config_value('assets_release', "", 'string')
-    app.add_config_value('assets_folder', "", 'string')
+    app.add_config_value('assets_local_openspace_folder', "", 'string')
 
     app.connect('config-inited', generate_docs)
 

--- a/conf.py
+++ b/conf.py
@@ -17,15 +17,15 @@ sys.path.append(str(Path('_ext').resolve()))
 ###
 
 # If true, always generate new files for the reference. If false, only generate if the
-# generated files do not alreday exist, to speed up the build process
+# generated files do not already exist, to speed up the build process
 generate_reference = False
 
 # Use github for getting the asset example files? Else, use a local folder. Set to false
 # to get the assets from a local OpenSpace version. Also specify the folder path below
 assets_examples_use_github = True
 
-# If using github for the examples, specify the release tag name here. If empty, will use
-# origin/master
+# If using github for the examples, specify the release tag name or the branch name here.
+# If empty, will use origin/master
 assets_release = ""
 
 # If using a local OpenSpace version for the examples, specify the path here

--- a/conf.py
+++ b/conf.py
@@ -8,23 +8,44 @@ sys.path.append(str(Path('_ext').resolve()))
 #                               Generate asset examples                                  #
 ##########################################################################################
 
-# If we are on Read the docs, get the RTD version and try to find that OS release
+###
+# Settings for Local Build (Developer)
+#
+# These settings controls if the files for the reference should be genereated and where
+# the files for the asset examples should be acquired from. When building locally, feel
+# free to change these settings to your liking, but do not commit the changes.
+###
+
+# If true, always generate new files for the reference. If false, only generate if the
+# generated files do not alreday exist, to speed up the build process
+generate_reference = False
+
+# Use github for getting the asset example files? Else, use a local folder. Set to false
+# to get the assets from a local OpenSpace version. Also specify the folder path below
+assets_examples_use_github = True
+
+# If using github for the examples, specify the release tag name here. If empty, will use
+# origin/master
+assets_release = ""
+
+# If using a local OpenSpace version for the examples, specify the path here
+assets_local_openspace_folder = ""
+
+
+
+###
+# Settings for Web Build
+###
+
+# If we are on Read the docs, get the RTD version and try to find that OS release. Also,
+# always generate the reference and use github for the asset files
 if (os.environ.get("READTHEDOCS")):
-  generate_assets_examples = True
+  generate_reference = True
   assets_examples_use_github = True
   assets_release = os.environ.get("READTHEDOCS_VERSION")
   print(f"Read the docs will look for the OpenSpace tag: {assets_release}")
-# If we are working on our local machine
-#elif os.path.exists("generated"):   #### Original test
-elif os.path.exists("reference/scripting-api"):
-  # If we already have the path, no need to copy files again
-  generate_assets_examples = False
-else:
-  # Dev options
-  generate_assets_examples = True # Generates asset examples if true
-  assets_examples_use_github = True # Use github for the examples? Else, local folder
-  assets_release = "" # Release tag name for github option. If empty, will use origin/master
-  assets_folder = "" # Folder path for local folder option
+
+
 
 
 ###

--- a/contribute/documentation/build-locally.md
+++ b/contribute/documentation/build-locally.md
@@ -1,47 +1,29 @@
 # How to build the documentation locally
 
-If you would like to contribute to the documentation, it can be a good idea to try out how the additions will look. This can be done by building the documentation locally. The documentation repository is [OpenSpace-Docs](https://github.com/OpenSpace/OpenSpace-Docs). It uses [Sphinx](https://www.sphinx-doc.org) to build the documentation that is hosted on [Read the docs](https://about.readthedocs.com/). 
+If you would like to contribute to the documentation, it can be a good idea to try out how the additions will look. This can be done by building the documentation locally. The documentation repository is [OpenSpace-Docs](https://github.com/OpenSpace/OpenSpace-Docs). It uses [Sphinx](https://www.sphinx-doc.org) to build the documentation that is hosted on [Read the docs](https://about.readthedocs.com/).
 
-The documentation uses two `JSON` files for the reference section. These `JSON` files are generated from the OpenSpace engine with an application called `DocsWriter`. These JSON files are updated manually to the `OpenSpace-Docs/json` folder. It is possible to build the documentation locally without generating new `JSON` files for the reference section.
+For details on how to build the documentation on locally, refer to [this part](https://github.com/OpenSpace/OpenSpace-Docs?tab=readme-ov-file#building-the-documentation-locally) of the README for the [OpenSpace-Docs](https://github.com/OpenSpace/OpenSpace-Docs) repository.
 
-## Build the documentation locally
+## Generate the OpenSpace reference (optional)
 
-1. Clone the [`OpenSpace-Docs`](https://github.com/OpenSpace/OpenSpace-Docs) repository.
+Note that the reference section of the documentation is generated automatically based on files from OpenSpace. If you are just working on markdown files for the documentation page, you do not need to care about the files that are used for the reference.
 
-2. Open the `OpenSpace-Docs` folder in a command prompt. Run the command `python -m venv .venv` to set up a virtual environment for python. If you wish, you may rename your environment to something else than `.venv`.
+However, if you are working on a local OpenSpace repository with for example writing asset examples or documentation for the `Asset Components` part of the referece and want to see those changes reflected in the local build of the documentation, you need to generate the files for the reference.
 
-3. Run the command `.\.venv\Scripts\activate` to activate your python virtual environment.
+Below is a short explanantion of the files used for the reference. More details on how to generate them are found in [this section of the README](https://github.com/OpenSpace/OpenSpace-Docs?tab=readme-ov-file#generate-openspace-reference-optional)
 
-4. Run the command `pip install sphinx`. This will install Sphinx, which is the documentation package used to generate the documentation.
+### `JSON` files from the `DocsWriter` application
 
-5. Run the command `pip install -U sphinx`. This will install all dependencies. Now we have set up our environment. 
+Most of the reference documentation is created based on two `JSON` files that are generated from the OpenSpace engine with an application called `DocsWriter`: `assetComponents.json` and `scriptingApi.json`. These JSON files are updated manually to the `OpenSpace-Docs/json` folder. It is possible to build the documentation locally without generating new `JSON` files for the reference section.
 
-6. (optional) If you generated the JSON files for the OpenSpace reference, move the two generated files `assetComponents.json` and `scriptingApi.json` to the `OpenSpace-Docs/json` folder.
-
-7. Run the command `make html` to generate the documentation webpage. To view it, open the `build` folder and open the `html/index.html` file in a browser.
-
-:::{note} Note about the asset examples
-The documentation uses the assets folder in OpenSpace to create examples for the `Asset Components` reference section. Per default, the script `make html` will download a partial clone of the OpenSpace repository (only the assets folder) from the _latest master_ and then generate the documentation.
-
-* **Remote branch**
-  If you wish to configure the asset examples to be created from another remote Git branch, you may change the name of the `OPENSPACE_BRANCH` variable in the `conf.py`-file. Whatever branch name you write here will be downloaded and used for the assets examples. The only requirement is that the branch has to be on `origin`. 
-
-* **Local branch**
-  If you instead wish to use a local copy of OpenSpace for the assets examples, you may use the variable called `LOCAL_OPENSPACE_FOLDER` in `conf.py`. If this variable is set, it will not use the branch from `origin`, but instead use a local copy of OpenSpace for the asset examples. The variable should be an absolute path.
+:::note
+OBS! When making a new build of the documentation, e.g. for a new OpenSpace version, the `assetComponents.json` and `scriptingApi.json` files should be committed to the repository.
 :::
 
-## Generate OpenSpace reference (optional)
-If you have updated documentation for the Scripting API or the Asset Components in the engine, you might want to view these changes in the documentation. The following steps describe how to do this.
+To use the `DocsWriter`, you first need to open your OpenSpace project in CMake and enable the `OPENSPACE_APPLICATION_DOCSWRITER` checkbox. Then, re-generate the project.
 
-1. Open your OpenSpace project in CMake and enable the `OPENSPACE_APPLICATION_DOCSWRITER` checkbox in CMake. Re-generate the project.
+![Enable the Cmake checkbox for the DocWriter](./cmake_docswriter.png)
 
-![Enable the Cmake checkbox for the DocWriter](./cmake_docswriter.png) 
+### Asset examples
 
-3. Once we have a project where the DocsWriter is generated, make the DocsWriter your startup project in Visual Studio.
-
-4. Build and run the DocsWriter project. This will generate two JSON files in the `documentation` folder: `assetComponents.json` and `scriptingApi.json`.
-
-5. If you wish to update the reference data for your locally built documentation webpage, replace the files with the same names in your `OpenSpace-Docs/json` folder with these two files (see step 6 in "Build the documentation locally").
-
-Done!
-
+The documentation uses the assets folder in OpenSpace to create examples for the `Asset Components` reference section. Per default, the script `make html` will download a partial clone of the OpenSpace repository (only the assets folder) from the _latest master_ and then generate the documentation.


### PR DESCRIPTION
Refactor developer settings for building the reference part of the documentation to make it easier to understand what to set to e.g. generate the examples from a local OpenSpace installation. Also: 
* add more detailed descriptions of the settings variables for generating the reference, 
* update the README to include info on generating the reference when building locally
* update outdated build-locally docs page, and remove duplicated information. Instead, it now links to the readme of the repository.

Please let me know if the descriptions are understandable.  